### PR TITLE
Compatibility for configs without profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,12 @@ File `package.json`:
     "scriptPreprocessor": "<rootDir>/__tests__/preprocessor.js",
   },
   "jest-webpack-alias": {
-    "webpackProfile": "dev"
+    // Required. If non-null value provided, will expect to find your webpack
+    // config stored at this key. Set to null for a regular webpack config file.
+    "webpackProfile": null
+
+    // optional, default is 'webpack.config.js'
+    "webpackConfigPath": 'webpack/config.dev.js'
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ File `package.json`:
     "scriptPreprocessor": "<rootDir>/__tests__/preprocessor.js",
   },
   "jest-webpack-alias": {
-    // Required. If non-null value provided, will expect to find your webpack
-    // config stored at this key. Set to null for a regular webpack config file.
+    // Required. If non-null value provided, will expect to find your webpack config stored at this key. Set to null
+    // for a regular webpack config file. See https://github.com/webpack/webpack/tree/master/examples/multi-compiler
+    // for details about webpack profiles/environments.
     "webpackProfile": null
 
-    // optional, default is 'webpack.config.js'
-    "webpackConfigPath": 'webpack/config.dev.js'
+    // optional, default is "webpack.config.js"
+    "webpackConfigPath": "webpack/config.dev.js"
   }
 }
 ```

--- a/lib/webpackInfo.js
+++ b/lib/webpackInfo.js
@@ -6,25 +6,34 @@ function read(pmodule, dir) {
   var packageJson = pkginfo.read(pmodule, dir);
   var pkgJsonFile = packageJson.dir; // misleading name from pkginfo library
   var pkgJsonDir = path.dirname(pkgJsonFile);
+
+  if (!_.has(packageJson['package'], 'jest-webpack-alias.webpackProfile')) {
+    throw new Error(
+      'Missing setting jest-webpack-alias.webpackProfile in ' + pkgJsonFile +
+      ". If you don't want to use a profile, set webpackProfile to null.");
+  }
   var webpackProfile = _.get(packageJson['package'], 'jest-webpack-alias.webpackProfile');
-  if (!webpackProfile) {
-    throw new Error('Missing setting jest-webpack-alias.webpackProfile in ' + pkgJsonFile);
-  }
 
-  var webpackFile = path.join(pkgJsonDir, 'webpack.config.js');
+  var webpackConfigPath = _.get(packageJson['package'],
+                                'jest-webpack-alias.webpackConfigPath',
+                                'webpack.config.js');
+  var webpackFile = path.join(pkgJsonDir, webpackConfigPath);
   var webpackSettings = require(webpackFile);
-  if (!webpackSettings[webpackProfile]) {
-    console.log('settings', webpackSettings);
-    throw new Error('Missing key "' + webpackProfile + '" in ' + webpackFile);
+
+  if (webpackProfile !== null) {
+    if (!webpackSettings[webpackProfile]) {
+      console.log('settings', webpackSettings);
+      throw new Error('Missing key "' + webpackProfile + '" in ' + webpackFile);
+    }
+    webpackSettings = webpackSettings[webpackProfile];
   }
 
-  var profSettings = webpackSettings[webpackProfile];
-  if (!_.get(profSettings, 'resolve.root')) {
+  if (!_.get(webpackSettings, 'resolve.root')) {
     throw new Error('Missing setting "' + webpackProfile + '.resolve.root' + '" in ' + webpackFile);
   }
 
   return {
-    config: profSettings,
+    config: webpackSettings,
     file: webpackFile
   };
 }

--- a/lib/webpackInfo.js
+++ b/lib/webpackInfo.js
@@ -14,9 +14,7 @@ function read(pmodule, dir) {
   }
   var webpackProfile = _.get(packageJson['package'], 'jest-webpack-alias.webpackProfile');
 
-  var webpackConfigPath = _.get(packageJson['package'],
-                                'jest-webpack-alias.webpackConfigPath',
-                                'webpack.config.js');
+  var webpackConfigPath = _.get(packageJson['package'], 'jest-webpack-alias.webpackConfigPath', 'webpack.config.js');
   var webpackFile = path.join(pkgJsonDir, webpackConfigPath);
   var webpackSettings = require(webpackFile);
 


### PR DESCRIPTION
My webpack config file doesn't have a profile, so I was very confused
trying to use jest-webpack-alias. Also I couldn't find any other
documentation on webpack profiles, so I'm not even certain they're a
thing.

Now a `webpackProfile: null` will opt-out of looking for the value at a
key and instead just use the entire exported object as the config.

Also, add support for custom webpack config file paths. Maybe consider
using separate files for dev versus prod profiles?

Closes #1.

Test plan:

`npm test` passes.
