### PR TITLE
support webpack 2 options

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -32,8 +32,16 @@ function ensureWebpackInfo(filename) {
   var modDirs = stringOrArray(resolveConfig.modulesDirectories) || defaultModulesDirs;
   var fallbackDirs = stringOrArray(resolveConfig.fallback) || defaultFallbackDirs;
 
-  moduleDirs = _.union(rootDirs, modDirs, fallbackDirs)
-  .map(function(dir) {
+  if (resolveConfig.modules) {
+    // webpack 2.x path names
+    moduleDirs = resolveConfig.modules;
+  }
+  else {
+    // webpack 1.x path names
+    moduleDirs = _.union(rootDirs, modDirs, fallbackDirs);
+  }
+
+  moduleDirs = moduleDirs.map(function(dir) {
     return path.resolve(webpackDir, dir);
   })
   .filter(function(dir) {

--- a/lib/webpackInfo.js
+++ b/lib/webpackInfo.js
@@ -30,8 +30,8 @@ function read(pmodule, dir) {
     }
   }
 
-  if (!_.get(webpackSettings, 'resolve.root')) {
-    throw new Error('Missing setting "resolve.root" in ' + webpackFile);
+  if (!_.get(webpackSettings, 'resolve.root') && !_.get(webpackSettings, 'resolve.modules')) {
+    throw new Error('Missing setting "resolve.root" or "resolve.modules" in ' + webpackFile);
   }
 
   return {

--- a/test/webpackInfo.test.js
+++ b/test/webpackInfo.test.js
@@ -87,7 +87,7 @@ describe('webpackInfo lib', function() {
       it('throws an error', function() {
         filename = '/top/test/file1.test.js';
         webpackFile = '/top/webpack/dev.config.js';
-        var expectedMsg = 'Missing setting "resolve.root" in /top/webpack/dev.config.js';
+        var expectedMsg = 'Missing setting "resolve.root" or "resolve.modules" in /top/webpack/dev.config.js';
 
         expect(webpackInfo.read.bind(null, {filename: filename})).to.throw(expectedMsg);
       });


### PR DESCRIPTION
Webpack 2 uses a single setting for modules.

See https://gist.github.com/sokra/27b24881210b56bbaff7#resolving-options
