### PR TITLE
Allow resolver to handle aliases with absolute paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ var computed = require(resolve(moduleName, __filename));
 
 ## Known issues
 
-- `resolve.alias` settings whose values are absolute paths might not work
 - `resolve.modulesDirectories` only searches the directory containing your package.json file, not all ancestors of current file
 
 ## License

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -47,7 +47,13 @@ function ensureWebpackInfo(filename) {
 }
 
 function firstDir(filename) {
-  return filename.split('/')[0];
+  var segments;
+
+  if (path.isAbsolute(filename)) {
+    return filename;
+  } else {
+    return filename.split('/')[0];
+  }
 }
 
 function matchAlias(dependency) {
@@ -73,12 +79,17 @@ function resolveExtension(matchingFirstDir, afterFirstDir) {
 }
 
 function locate(dirname) {
-  var matchingExt;
+  var matchingDir, matchingExt;
 
-  var matchingDir = _.find(moduleDirs, function(candidate) {
-    matchingExt = resolveExtension(candidate, dirname);
-    return matchingExt !== undefined;
-  });
+  if (path.isAbsolute(dirname)) {
+    matchingDir = dirname;
+    matchingExt = resolveExtension(dirname);
+  } else {
+    matchingDir = _.find(moduleDirs, function(candidate) {
+      matchingExt = resolveExtension(candidate, dirname);
+      return matchingExt !== undefined;
+    });
+  }
 
   return {
     dir: matchingDir,
@@ -128,7 +139,12 @@ function resolve(dependency, filename) {
     return dependency;
   }
 
-  var matchingDir = path.join(match.dir, dirname);
+  var matchingDir;
+  if (path.isAbsolute(dirname)) {
+    matchingDir = dirname;
+  } else {
+    matchingDir = path.join(match.dir, dirname);
+  }
   var relative = resolveDependencyToMatch(matchingDir, rest, filename);
   var ext = match.ext || '';
 

--- a/test/fixture/basic.js
+++ b/test/fixture/basic.js
@@ -38,7 +38,9 @@ var webpackSettings = fixture.webpackSettings = [
         aliasNodeSubdir1Src: 'node1',
         aliasNodeSubdir2Src: 'node1/lib/submodule',
         aliasNodeFileSrc: 'aliasNodeFileDest',
-        aliasPlainSubdirSrc: 'dir1/lib1a'
+        aliasPlainSubdirSrc: 'dir1/lib1a',
+        aliasAbsoluteSubdirSrc: '/top/src/dir1',
+        aliasAbsoluteFileSrc: '/top/src/dir1/lib1a'
       }
     }
   }

--- a/test/preprocessor.test.js
+++ b/test/preprocessor.test.js
@@ -336,6 +336,30 @@ describe('jest-webpack-alias module', function() {
       ]);
       expect(output).to.eq("var lib1a = require('../src/aliasRelative.js');");
     });
+
+    it('applies alias to absolute subdir paths', function () {
+      var src = "var lib1a = require('aliasAbsoluteSubdirSrc/lib1a');";
+      var output = webpackAlias.process(src, filename);
+
+      verifyDirHas([
+        ['/top/src/dir1', 'lib1a'],
+        ['/top/src/dir1', 'lib1a.js'],
+      ]);
+
+      expect(output).to.eq("var lib1a = require('../src/dir1/lib1a.js');");
+    });
+
+    it('applies alias to absolute path to a file', function() {
+      var src = "var lib1a = require('aliasAbsoluteFileSrc');";
+      var output = webpackAlias.process(src, filename);
+
+      verifyDirHas([
+        ['/top/src/dir1', 'lib1a'],
+        ['/top/src/dir1', 'lib1a.js'],
+      ]);
+
+      expect(output).to.eq("var lib1a = require('../src/dir1/lib1a.js');");
+    });
   });
 
   describe('resolve', function() {


### PR DESCRIPTION
This fixes #21
