### PR TITLE
Feature/relative alias

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -62,7 +62,8 @@ function matchAlias(dependency) {
     var dirname = firstDir(alias);
     return {
       dirname: dirname,
-      rest: alias.slice(dirname.length + 1)
+      rest: alias.slice(dirname.length + 1),
+      path: alias
     };
   } else {
     return undefined;
@@ -129,8 +130,13 @@ function resolve(dependency, filename) {
 
   var alias = matchAlias(dirname);
   if (alias) {
-    dirname = alias.dirname;
-    rest = alias.rest || rest;
+    // We want to get something relative to the alias
+    if (rest) {
+      dirname = alias.path;
+    } else {
+      dirname = alias.dirname;
+      rest = alias.rest;
+    }
     dependency = dirname + (rest ? '/' + rest : '');
   }
 

--- a/test/fixture/basic.js
+++ b/test/fixture/basic.js
@@ -40,7 +40,8 @@ var webpackSettings = fixture.webpackSettings = [
         aliasNodeFileSrc: 'aliasNodeFileDest',
         aliasPlainSubdirSrc: 'dir1/lib1a',
         aliasAbsoluteSubdirSrc: '/top/src/dir1',
-        aliasAbsoluteFileSrc: '/top/src/dir1/lib1a'
+        aliasAbsoluteFileSrc: '/top/src/dir1/lib1a',
+        aliasSubRelative: 'dir1/dir1-1',
       }
     }
   }

--- a/test/preprocessor.test.js
+++ b/test/preprocessor.test.js
@@ -362,13 +362,14 @@ describe('jest-webpack-alias module', function() {
     });
 
     it('applies alias when wanted file is relative to alias', function() {
-      var src = "var lib11a = require('aliasSubRelative/lib1-1a.js');";
+      var src = "var lib11a = require('aliasSubRelative/lib1-1a');";
       var output = webpackAlias.process(src, filename);
 
       verifyDirHas([
+        [ '/top/test/__mocks__/dir1/dir1-1', 'lib1-1a' ],
         [ '/top/test/__mocks__/dir1/dir1-1', 'lib1-1a.js' ],
-        [ '/top/test/__mocks__/dir1/dir1-1', 'lib1-1a.js.js' ],
-        [ '/top/test/__mocks__/dir1/dir1-1', 'lib1-1a.js.jsx' ],
+        [ '/top/test/__mocks__/dir1/dir1-1', 'lib1-1a.jsx' ],
+        [ '/top/src/dir1/dir1-1', 'lib1-1a' ],
         [ '/top/src/dir1/dir1-1', 'lib1-1a.js' ]
       ]);
 

--- a/test/preprocessor.test.js
+++ b/test/preprocessor.test.js
@@ -360,6 +360,20 @@ describe('jest-webpack-alias module', function() {
 
       expect(output).to.eq("var lib1a = require('../src/dir1/lib1a.js');");
     });
+
+    it('applies alias when wanted file is relative to alias', function() {
+      var src = "var lib11a = require('aliasSubRelative/lib1-1a.js');";
+      var output = webpackAlias.process(src, filename);
+
+      verifyDirHas([
+        [ '/top/test/__mocks__/dir1/dir1-1', 'lib1-1a.js' ],
+        [ '/top/test/__mocks__/dir1/dir1-1', 'lib1-1a.js.js' ],
+        [ '/top/test/__mocks__/dir1/dir1-1', 'lib1-1a.js.jsx' ],
+        [ '/top/src/dir1/dir1-1', 'lib1-1a.js' ]
+      ]);
+
+      expect(output).to.eq("var lib11a = require('../src/dir1/dir1-1/lib1-1a.js');");
+    });
   });
 
   describe('resolve', function() {


### PR DESCRIPTION
support for when alias is:

```
alias: {
  components: 'src/client/components/',
}
```

and trying to require

```
var Comp1 = require('components/Comp1');
```
